### PR TITLE
Fog of war server side

### DIFF
--- a/agot-bg-game-server/src/client/CombatInfoComponent.tsx
+++ b/agot-bg-game-server/src/client/CombatInfoComponent.tsx
@@ -34,7 +34,6 @@ interface HouseCombatData {
 
 interface CombatInfoComponentProps {
     housesCombatData: HouseCombatData[];
-    fogOfWar?: boolean
 }
 
 @observer
@@ -69,25 +68,17 @@ export default class CombatInfoComponent extends Component<CombatInfoComponentPr
                 </div>
             </div>
             <div style={{display: "grid", gridGap: "5px", gridTemplateColumns: "auto 1fr auto 1fr auto", justifyItems: "center", alignItems: "center"}} className="text-center">
-                {
-                    !this.props.fogOfWar && (
-                        <div style={{gridRow: "1", gridColumn: "1 / span 2"}}>
-                            <small>{this.attacker.region.name}</small>
-                        </div>
-                    )
-                }
+                <div style={{gridRow: "1", gridColumn: "1 / span 2"}}>
+                    <small>{this.attacker.region.name}</small>
+                </div>
 
                 <div style={{gridRow: "1 / span 2", gridColumn: "3"}}>
                     <img src={crossedSwordsImage} width={this.SIZE_MIDDLE_COLUMN}/>
                 </div>
 
-                {
-                    !this.props.fogOfWar && (
-                        <div style={{gridRow: "1", gridColumn: "4 / span 2"}}>
-                            <small>{this.defender.region.name}</small>
-                        </div>
-                    )
-                }
+                <div style={{gridRow: "1", gridColumn: "4 / span 2"}}>
+                    <small>{this.defender.region.name}</small>
+                </div>
 
                 <div style={{gridRow: "2", gridColumn: "1 / span 2"}}>
                     {this.attacker.armyUnits.map((ut, i) =>

--- a/agot-bg-game-server/src/client/EntireGameComponent.tsx
+++ b/agot-bg-game-server/src/client/EntireGameComponent.tsx
@@ -271,7 +271,7 @@ export default class EntireGameComponent extends Component<EntireGameComponentPr
                     <h4><Badge variant="primary"><FontAwesomeIcon icon={faTriangleExclamation} /></Badge></h4>
                 </OverlayTrigger>
             </Col>}
-            {false &&
+            {this.props.entireGame.gameSettings.fogOfWar &&
             <Col xs="auto">
                 <h4><Badge variant="warning">BETA</Badge></h4>
             </Col>}

--- a/agot-bg-game-server/src/client/GameSettingsComponent.tsx
+++ b/agot-bg-game-server/src/client/GameSettingsComponent.tsx
@@ -694,7 +694,7 @@ export default class GameSettingsComponent extends Component<GameSettingsCompone
                                 <Tooltip id="fog-of-war-setting-tooltip">
                                     Limit visibility to controlled regions, adjacent regions, and regions you attack or are attacked from.
                                 </Tooltip>}>
-                                <label htmlFor="fog-of-war-setting">Fog of War</label>
+                                <label htmlFor="fog-of-war-setting">Fog of War <i>(BETA!)</i></label>
                             </OverlayTrigger>}
                         checked={this.gameSettings.fogOfWar}
                         onChange={() => this.changeGameSettings(() => this.gameSettings.fogOfWar = !this.gameSettings.fogOfWar)}

--- a/agot-bg-game-server/src/client/IngameComponent.tsx
+++ b/agot-bg-game-server/src/client/IngameComponent.tsx
@@ -254,7 +254,6 @@ export default class IngameComponent extends Component<IngameComponentProps> {
                             gameClient={this.gameClient}
                             ingameGameState={this.ingame}
                             mapControls={this.mapControls}
-                            authenticatedPlayer={this.authenticatedPlayer}
                         />
                     </div>
                     </Col>}
@@ -1235,34 +1234,18 @@ export default class IngameComponent extends Component<IngameComponentProps> {
 
     highlightRegionsOfHouses(): void {
         const regions = new BetterMap(this.ingame.world.regions.values.map(r => [r, r.getController()]));
-
-        let adjacentRegionIds: string[] = []
-
-        if (this.authenticatedPlayer) {
-            adjacentRegionIds = this.ingame.world.getRegionIdsAdjacent(
-                this.authenticatedPlayer?.house
-            )
-        }
-        
         this.highlightedRegions.clear();
 
-        regions.entries
-            .filter(([r]) => {
-                if (!this.ingame.entireGame.gameSettings.fogOfWar) {
-                    return true
+        regions.entries.forEach(([r, controller]) => {
+            this.highlightedRegions.set(r, {
+                highlight: {
+                    active: controller != null ? true : false,
+                    color: controller?.id != "greyjoy" ? controller?.color ?? "#000000" : "#000000",
+                    light: r.type.id == "sea",
+                    strong: r.type.id == "land"
                 }
-                return adjacentRegionIds.includes(r.id)
-            })
-            .forEach(([r, controller]) => {
-                this.highlightedRegions.set(r, {
-                    highlight: {
-                        active: controller != null ? true : false,
-                        color: controller?.id != "greyjoy" ? controller?.color ?? "#000000" : "#000000",
-                        light: r.type.id == "sea",
-                        strong: r.type.id == "land"
-                    }
-                });
             });
+        });
     }
 
     renderDragonStrengthTooltip(): OverlayChildren {

--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -43,7 +43,6 @@ import invertColor from "./utils/invertColor";
 import ImagePopover from "./utils/ImagePopover";
 import renderLoanCardsToolTip from "./loanCardsTooltip";
 import Xarrow from "react-xarrows";
-import Player from "../common/ingame-game-state/Player";
 
 export const MAP_HEIGHT = 1378;
 export const MAP_WIDTH = 741;
@@ -53,16 +52,12 @@ interface MapComponentProps {
     gameClient: GameClient;
     ingameGameState: IngameGameState;
     mapControls: MapControls;
-    authenticatedPlayer: Player | null;
 }
 
 @observer
 export default class MapComponent extends Component<MapComponentProps> {
     backgroundImage: string = westerosImage;
     mapWidth: number = MAP_WIDTH;
-    fogOfWarObject = {
-        fogOfWar: true,
-    };
 
     get ingame(): IngameGameState {
         return this.props.ingameGameState;
@@ -81,10 +76,6 @@ export default class MapComponent extends Component<MapComponentProps> {
                     : westerosImage;
 
         this.mapWidth = this.ingame.entireGame.gameSettings.playerCount >= 8 ? DELUXE_MAT_WIDTH : MAP_WIDTH;
-
-        // this.fogOfWarObject.fogOfWar = this.ingame.entireGame.gameSettings.fogOfWar;
-        // Make sure this can't be toggled client-side.
-        Object.freeze(this.fogOfWarObject)
     }
 
     render(): ReactNode {
@@ -131,7 +122,7 @@ export default class MapComponent extends Component<MapComponentProps> {
             { }
         );
 
-        const nonFoggedRegions = this.getNonFoggedRegions(propertiesForUnits)
+        const visibleRegions = this.ingame.getVisibleRegionsForPlayer(this.props.gameClient.authenticatedPlayer);
 
         return (
             <div className="map"
@@ -139,7 +130,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                 <div style={{ position: "relative" }}>
                     {this.ingame.world.regions.values.map(r => (
                         <div key={`map_${r.id}`}>
-                            {(!this.getIsFoggedRegion(nonFoggedRegions, r.id)) && castleModifiers.has(r.id) && (
+                            {castleModifiers.has(r.id) && (
                                 <OverlayTrigger
                                     overlay={renderRegionTooltip(r)}
                                     delay={{ show: 750, hide: 100 }}
@@ -155,9 +146,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                                     />
                                 </OverlayTrigger>
                             )}
-                            {(barrelModifiers.has(r.id) || crownModifiers.has(r.id)) 
-                            && (!this.getIsFoggedRegion(nonFoggedRegions, r.id))
-                            && this.renderImprovements(r)}
+                            {(barrelModifiers.has(r.id) || crownModifiers.has(r.id)) && this.renderImprovements(r)}
                             {r.overwrittenSuperControlPowerToken &&
                                 <OverlayTrigger
                                     overlay={<Tooltip id={"power-token-" + r.id}>
@@ -179,7 +168,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                                     </div>
                                 </OverlayTrigger>
                             }
-                            {(!this.getIsFoggedRegion(nonFoggedRegions, r.id)) && r.controlPowerToken && (
+                            {r.controlPowerToken && (
                                 <OverlayTrigger
                                     overlay={<Tooltip id={"power-token-" + r.id}>
                                         <div className="text-center"><b>Power token</b><small> of <b>{r.controlPowerToken.name}<br />{r.name}</b></small></div>
@@ -203,28 +192,27 @@ export default class MapComponent extends Component<MapComponentProps> {
                         </div>
                     ))}
                     {this.renderUnits(propertiesForUnits, garrisons, disablePointerEventsForUnits)}
-                    {this.renderOrders(propertiesForUnits)}
+                    {this.renderOrders(visibleRegions)}
                     {this.renderRegionTexts(propertiesForRegions)}
                     {this.renderIronBankInfos(ironBankView)}
                     {this.renderLoanCardDeck(ironBankView)}
                     {this.renderLoanCardSlots(ironBankView)}
-                    {this.renderMarchMarkers(propertiesForUnits)}
+                    {this.renderMarchMarkers(propertiesForUnits, visibleRegions)}
                 </div>
                 <svg style={{ width: `${this.mapWidth}px`, height: `${MAP_HEIGHT}px` }}>
-                    {this.renderRegions(propertiesForRegions, propertiesForUnits)}
+                    {this.renderRegions(propertiesForRegions, visibleRegions)}
                 </svg>
             </div>
         )
     }
 
-    renderMarchMarkers(propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>): ReactNode[] {
-        const markers = this.getMarkers(propertiesForUnits)
+    renderMarchMarkers(propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>, visibleRegions: Region[]): ReactNode[] {
+        const markers = _.unionBy(
+            propertiesForUnits.entries.filter(([_u, uprop]) => uprop.targetRegion != undefined).map(([u, uprop]) => [u, uprop.targetRegion] as [Unit, Region]),
+            this.ingame.marchMarkers.entries, ([u, _r]) => u.id)
+            .filter(([u, r]) => u.region != r && (this.props.gameClient.doesControlHouse(u.allegiance) || (visibleRegions.includes(u.region) && (visibleRegions.includes(r)))));
 
-        const nonFoggedRegions = this.getNonFoggedRegions(propertiesForUnits)
-
-        return markers
-        .filter(([unit, to]) => nonFoggedRegions.includes(unit.region.id) && nonFoggedRegions.includes(to.id))
-        .map(([unit, to]) =>
+        return markers.map(([unit, to]) =>
             <Xarrow
                 key={`arrow-${unit.id}-${to.id}`}
                 start={`centered-unit-div-for-march-markers-${unit.id}`}
@@ -287,135 +275,16 @@ export default class MapComponent extends Component<MapComponentProps> {
         </div>;
     }
 
-    private getMarkers(propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>) {
-        return _.unionBy(
-            propertiesForUnits.entries.filter(([_u, uprop]) => uprop.targetRegion != undefined).map(([u, uprop]) => [u, uprop.targetRegion] as [Unit, Region]),
-            this.ingame.marchMarkers.entries, ([u, _r]) => u.id)
-            .filter(([u, r]) => u.region != r);
-    }
-
-    private getNonFoggedRegions(propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>): string[] {
-        const adjacent = this.props.authenticatedPlayer ? this.ingame.world.getRegionIdsAdjacent(
-            this.props.authenticatedPlayer.house,
-        ) : [];
-
-        const vassalsOwned = this.ingame.game.vassalRelations.entries
-            .filter(([_, owner]) => owner.id === this?.props?.authenticatedPlayer?.house?.id)
-            .map(([vassal]) => vassal)
-
-        vassalsOwned.forEach((vassal) => {
-            const adjacentToVassal = this.props.authenticatedPlayer ? this.ingame.world.getRegionIdsAdjacent(
-                vassal,
-            ) : [];
-            adjacent.push(...adjacentToVassal)
-        })
-
-        const markers = this.getMarkers(propertiesForUnits)
-
-        if (markers.length) {
-            const [markedUnit, markedRegion] = markers[0]
-
-            if (markedUnit.allegiance.id === this.props?.authenticatedPlayer?.house.id) {
-                // Player is attacker, reveal surrounding regions
-                const neighboringToMarkedRegion = this.ingame.world.getNeighbouringRegions(markedRegion)
-                return _.uniq([
-                    ...adjacent, 
-                    markedRegion.id,
-                    markedUnit.region.id,
-                    ...neighboringToMarkedRegion.map(region => region.id)
-                ])
-            } else if (adjacent.includes(markedRegion.id)) {
-                // Adjacent to region being entered: check if this region includes your units or vassal units.
-                if (this.ingame.world.hasUnitsInRegion(markedRegion.id, this?.props?.authenticatedPlayer?.house)
-                    || vassalsOwned.some((house) => this.ingame.world.hasUnitsInRegion(markedRegion.id, house))
-                ) {
-                    // If so, a battle is starting and you should include the source unit's region.
-                    return _.uniq([
-                        ...adjacent, 
-                        markedUnit.region.id,
-                        markedRegion.id,
-                    ])
-                } else {
-                    // You don't have units there and should not see the region the unit is coming from.
-                    return _.uniq([
-                        ...adjacent,
-                        markedRegion.id,
-                    ])
-                }
-            } else if (adjacent.includes(markedUnit.region.id)) {
-                return _.uniq([
-                    ...adjacent,
-                    markedUnit.region.id,
-                ])
-            }
-        }
-
-        return adjacent
-    }
-
-    private isFoggedForUnit(
-        unitId: number,
-        regionId: string,
-        isFoggedRegion: boolean,
-        propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>
-    ): boolean {
-        if (!this.fogOfWarObject.fogOfWar) return false
-
-        const markers = this.getMarkers(propertiesForUnits)
-
-        if (!markers.length) {
-            return isFoggedRegion
-        }
-
-        const [markedUnit, markedRegion] = markers[0]
-
-        // Units belong to player - show all units
-        if (markedUnit.allegiance.id === this.props?.authenticatedPlayer?.house.id) {
-            return false
-        }
-
-        // Region being attacked should also show all units
-        if (markedRegion.id === regionId) return false
-
-        const matchingUnit = markers.find(markerArray => {
-            const [unit] = markerArray
-            return unit.id === unitId
-        })
-
-        // If one of the units attacking matches the unit ID, show it
-        if (matchingUnit) return false
-
-        const adjacent = this.props.authenticatedPlayer ? this.ingame.world.getRegionIdsAdjacent(
-            this.props.authenticatedPlayer.house,
-        ) : [];
-
-        // Show all units if the region the units are attacking from is adjacent.
-        if (markedUnit.region.id === regionId && !adjacent.includes(regionId)) {
-            return true
-        }
-
-        // Hide the unit if the area is fogged in general
-        return isFoggedRegion
-    }
-
-    private getIsFoggedRegion(nonFoggedRegions: string[], regionId: string): boolean {
-        const isFogged = !nonFoggedRegions.includes(regionId)
-        return this.fogOfWarObject.fogOfWar ? isFogged : false
-    }
-
-    renderRegions(
-        propertiesForRegions: BetterMap<Region, RegionOnMapProperties>,
-        propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>
-    ): ReactNode {
-        const nonFoggedRegions = this.getNonFoggedRegions(propertiesForUnits)
-
+    renderRegions(propertiesForRegions: BetterMap<Region, RegionOnMapProperties>, visibleRegions: Region[]): ReactNode {
         return propertiesForRegions.entries.map(([region, properties]) => {
             const wrap = properties.wrap;
 
-            const isFoggedRegion = this.getIsFoggedRegion(nonFoggedRegions, region.id)
-
-            const fillColor = region.isBlocked ? "black" 
-            : (isFoggedRegion ? "#3d3d3d" : properties.highlight.color)
+            const isFoggedRegion = !visibleRegions.includes(region);
+            const fillColor = region.isBlocked
+                ? "black"
+                : isFoggedRegion
+                    ? "#3d3d3d"
+                    : properties.highlight.color;
 
             return (
                 <ConditionalWrap condition={!region.isBlocked}
@@ -475,8 +344,6 @@ export default class MapComponent extends Component<MapComponentProps> {
 
     renderUnits(propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>, garrisons: BetterMap<string, string | null>, disablePointerEvents: boolean): ReactNode {
         const garrisonControllers = new BetterMap(garrisons.keys.map(rid => [rid, this.ingame.world.regions.get(rid).getController()]));
-        
-        const nonFoggedRegions = this.getNonFoggedRegions(propertiesForUnits)
 
         return this.ingame.world.regions.values.map(r => {
             let disablePointerEventsForCurrentRegion = disablePointerEvents;
@@ -485,19 +352,13 @@ export default class MapComponent extends Component<MapComponentProps> {
                 disablePointerEventsForCurrentRegion = false;
             }
 
-            const isFoggedRegion = this.getIsFoggedRegion(nonFoggedRegions, r.id)
-
             const controller = r.getController();
-
             return <div
                 key={`map-units_${r.id}`}
                 className={classNames("units-container", { "disable-pointer-events": disablePointerEventsForCurrentRegion })}
                 style={{ left: r.unitSlot.point.x, top: r.unitSlot.point.y, width: r.unitSlot.width, flexWrap: r.type == land ? "wrap-reverse" : "wrap" }}
             >
-                {!isFoggedRegion
-                && r.allUnits
-                .filter(u => !this.isFoggedForUnit(u.id, r.id, isFoggedRegion, propertiesForUnits))
-                .map(u => {
+                {r.allUnits.map(u => {
                     const property = propertiesForUnits.get(u);
                     let opacity: number;
                     // css transform
@@ -554,7 +415,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                         </div>
                     </OverlayTrigger>
                 })}
-                {!isFoggedRegion && garrisons.has(r.id) && (
+                {garrisons.has(r.id) && (
                     <OverlayTrigger
                         overlay={<Tooltip id={"garrison-tooltip-" + r.id}>
                             <div className="text-center">
@@ -579,7 +440,7 @@ export default class MapComponent extends Component<MapComponentProps> {
                         </div>
                     </OverlayTrigger>
                 )}
-                {!isFoggedRegion && r.loyaltyTokens > 0 && (
+                {r.loyaltyTokens > 0 && (
                     <OverlayTrigger
                         overlay={<Tooltip id={"loyalty-tooltip-" + r.id}>
                             <div className="text-center"><b>Loyalty token</b><br /><small><b>{r.name}</b></small></div>
@@ -648,25 +509,20 @@ export default class MapComponent extends Component<MapComponentProps> {
         </div>
     }
 
-    renderOrders(
-        propertiesForUnits: BetterMap<Unit, UnitOnMapProperties>
-    ): ReactNode {
+    renderOrders(visibleRegions: Region[]): ReactNode {
         const propertiesForOrders = this.getModifiedPropertiesForEntities<Region, OrderOnMapProperties>(
             _.flatMap(this.ingame.world.regions.values),
             this.props.mapControls.modifyOrdersOnMap,
             { }
         );
 
-        const nonFoggedRegions = this.getNonFoggedRegions(propertiesForUnits)
-
         return propertiesForOrders.map((region, properties) => {
-            let order: Order | null = null;
-            let orderPresent = false;
-
-            if (this.fogOfWarObject.fogOfWar && !nonFoggedRegions.includes(region.id)) {
-                return null
+            if (!visibleRegions.includes(region)) {
+                return null;
             }
 
+            let order: Order | null = null;
+            let orderPresent = false;
             if (this.ingame.childGameState instanceof PlanningGameState && this.ingame.childGameState.childGameState instanceof PlaceOrdersGameState) {
                 const placeOrders = this.ingame.childGameState.childGameState;
                 orderPresent = placeOrders.placedOrders.has(region);

--- a/agot-bg-game-server/src/client/MapComponent.tsx
+++ b/agot-bg-game-server/src/client/MapComponent.tsx
@@ -325,16 +325,11 @@ export default class MapComponent extends Component<MapComponentProps> {
                     ...neighboringToMarkedRegion.map(region => region.id)
                 ])
             } else if (adjacent.includes(markedRegion.id)) {
-                // Adjacent to region being entered: check if this region includes your units.
-                if (this.ingame.world.hasUnitsInRegion(markedRegion.id, this?.props?.authenticatedPlayer?.house)) {
+                // Adjacent to region being entered: check if this region includes your units or vassal units.
+                if (this.ingame.world.hasUnitsInRegion(markedRegion.id, this?.props?.authenticatedPlayer?.house)
+                    || vassalsOwned.some((house) => this.ingame.world.hasUnitsInRegion(markedRegion.id, house))
+                ) {
                     // If so, a battle is starting and you should include the source unit's region.
-                    return _.uniq([
-                        ...adjacent, 
-                        markedUnit.region.id,
-                        markedRegion.id,
-                    ])
-                } else if (vassalsOwned.some((house) => this.ingame.world.hasUnitsInRegion(markedRegion.id, house))) {
-                    // Your vassal is being attacked and you can also see this.
                     return _.uniq([
                         ...adjacent, 
                         markedUnit.region.id,

--- a/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
+++ b/agot-bg-game-server/src/client/game-state-panel/CombatComponent.tsx
@@ -63,10 +63,6 @@ export default class CombatComponent extends Component<GameStateComponentProps<C
         return this.combat.stats;
     }
 
-    get fogOfWar(): boolean {
-        return this.props.gameClient.entireGame?.gameSettings.fogOfWar || false
-    }
-
     render(): ReactNode {
         // If combatStats have been set by PostCombatState show the fixed dialog, otherwise the dynamic one!
         const winners = this.combatStats.filter(cs => cs.isWinner);
@@ -127,28 +123,12 @@ export default class CombatComponent extends Component<GameStateComponentProps<C
                 <Col xs={12}>
                     {this.combat.rerender >= 0 && (
                         <>
-                            {
-                                this.fogOfWar ? 
-                                (
-                                    <div style={{ display: 'flex', justifyContent: 'center' }}>
-                                        <h5>
-                                            Battle {this.combatStats.length > 0 && "results "}
-                                        </h5>
-                                    </div>
-                                )
-                                :
-                                (
-                                    <div style={{ display: 'flex', justifyContent: 'center' }}>
-                                        <h5>
-                                            Battle {this.combatStats.length > 0 && "results "} for <b>{this.combat.defendingRegion.name}</b>
-                                        </h5>
-                                    </div>
-                                )
-                            }
+                            <div style={{ display: 'flex', justifyContent: 'center' }}>
+                                <h5>Battle {this.combatStats.length > 0 && "results "} for <b>{this.combat.defendingRegion.name}</b></h5>
+                            </div>
                             <div style={{ display: 'flex', justifyContent: 'center' }}>
                                 <CombatInfoComponent
                                     housesCombatData={houseCombatDatas}
-                                    fogOfWar={this.fogOfWar}
                                 />
                             </div>
                         </>
@@ -202,7 +182,7 @@ export default class CombatComponent extends Component<GameStateComponentProps<C
         // or the user does not control the house to select units but never show march markers when attacker lost the combat
         // (but post combat may be still active for abilties)
         const postCombat = this.combat.childGameState instanceof PostCombatGameState ? this.combat.childGameState : null;
-        const drawMarchMarkers = !postCombat || (!postCombat.hasChildGameState(AfterCombatHouseCardAbilitiesGameState) && postCombat.winner == this.combat.attacker);
+        const drawMarchMarkers = !this.combat.ingameGameState.fogOfWar && (!postCombat || (!postCombat.hasChildGameState(AfterCombatHouseCardAbilitiesGameState) && postCombat.winner == this.combat.attacker));
         const selectUnits = this.combat.hasChildGameState(SelectUnitsGameState) ? this.combat.getChildGameState(SelectUnitsGameState) as SelectUnitsGameState<any>: null;
 
         if (!selectUnits || !this.props.gameClient.doesControlHouse(selectUnits.house)) {

--- a/agot-bg-game-server/src/common/EntireGame.ts
+++ b/agot-bg-game-server/src/common/EntireGame.ts
@@ -130,7 +130,7 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
 
     get minPlayerCount(): number {
         // For Debug we can manipulate this to allow games with only 1 player
-        //return 1;
+        // return 1;
         return this.gameSettings.playerCount >= 8 ? 4 : 3;
     }
 
@@ -402,6 +402,10 @@ export default class EntireGame extends GameState<null, LobbyGameState | IngameG
         this.doPlayerClocksHandling();
 
         this.saveGame(updateLastActive);
+
+        if (gameStateChanged) {
+            this.ingameGameState?.updateVisibleRegions();
+        }
     }
 
     doPlayerClocksHandling(): void {

--- a/agot-bg-game-server/src/common/GameState.ts
+++ b/agot-bg-game-server/src/common/GameState.ts
@@ -4,6 +4,8 @@ import EntireGame from "./EntireGame";
 import User from "../server/User";
 import House from "./ingame-game-state/game-data-structure/House";
 import { v4 } from "uuid";
+import Region from "./ingame-game-state/game-data-structure/Region";
+import Player from "./ingame-game-state/Player";
 
 type AnyGameState = GameState<any, any> | null;
 
@@ -117,6 +119,10 @@ export default class GameState<ParentGameState extends AnyGameState, ChildGameSt
     }
 
     actionAfterVassalReplacement(_newVassal: House): void {
+    }
+
+    getRequiredVisibleRegionsForPlayer(_player: Player): Region[] {
+        return [];
     }
 }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/ActionGameState.ts
@@ -1,6 +1,6 @@
 import IngameGameState from "../IngameGameState";
 import GameState from "../../GameState";
-import Region, { RegionSnapshot } from "../game-data-structure/Region";
+import Region from "../game-data-structure/Region";
 import Order from "../game-data-structure/Order";
 import EntireGame from "../../EntireGame";
 import ResolveMarchOrderGameState, {SerializedResolveMarchOrderGameState} from "./resolve-march-order-game-state/ResolveMarchOrderGameState";
@@ -14,7 +14,7 @@ import RaidOrderType from "../game-data-structure/order-types/RaidOrderType";
 import UseRavenGameState, {SerializedUseRavenGameState} from "./use-raven-game-state/UseRavenGameState";
 import ResolveRaidOrderGameState, {SerializedResolveRaidOrderGameState} from "./resolve-raid-order-game-state/ResolveRaidOrderGameState";
 import BetterMap from "../../../utils/BetterMap";
-import Game, { GameSnapshot } from "../game-data-structure/Game";
+import Game from "../game-data-structure/Game";
 import ResolveConsolidatePowerGameState, {SerializedResolveConsolidatePowerGameState} from "./resolve-consolidate-power-game-state/ResolveConsolidatePowerGameState";
 import ConsolidatePowerOrderType from "../game-data-structure/order-types/ConsolidatePowerOrderType";
 import SupportOrderType from "../game-data-structure/order-types/SupportOrderType";
@@ -30,7 +30,6 @@ import IronBankOrderType from "../game-data-structure/order-types/IronBankOrderT
 import ReconcileArmiesGameState, { SerializedReconcileArmiesGameState } from "../westeros-game-state/reconcile-armies-game-state/ReconcileArmiesGameState";
 import popRandom from "../../../utils/popRandom";
 import ScoreObjectivesGameState, { SerializedScoreObjectivesGameState } from "./score-objectives-game-state/ScoreObjectivesGameState";
-import _ from "lodash";
 
 export default class ActionGameState extends GameState<IngameGameState, UseRavenGameState | ResolveRaidOrderGameState
                                                                         | ResolveMarchOrderGameState | ResolveConsolidatePowerGameState
@@ -193,7 +192,7 @@ export default class ActionGameState extends GameState<IngameGameState, UseRaven
 
             if (order) {
                 this.ordersOnBoard.set(region, order);
-                if (message.animate) {
+                if (message.animate && !this.ingame.fogOfWar) {
                     this.ingame.ordersToBeAnimated.set(region,
                         {highlight: {active: true, color: message.animate}, animateAttention: true});
                     window.setTimeout(() => {
@@ -202,7 +201,7 @@ export default class ActionGameState extends GameState<IngameGameState, UseRaven
                 }
             } else {
                 if (this.ordersOnBoard.has(region)) {
-                    if (message.animate) {
+                    if (message.animate && !this.ingame.fogOfWar) {
                         this.ingame.ordersToBeAnimated.set(region,
                             {highlight: {active: true, color: message.animate}, animateFadeOut: true});
                         window.setTimeout(() => {

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/execute-loan-game-state/place-sellwords-game-state/PlaceSellswordsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/execute-loan-game-state/place-sellwords-game-state/PlaceSellswordsGameState.ts
@@ -73,11 +73,8 @@ export default class PlaceSellswordsGameState extends GameState<ExecuteLoanGameS
                     region.units.set(unit.id, unit);
                     return unit;
                 });
-                this.entireGame.broadcastToClients({
-                    type: "add-units",
-                    regionId: region.id,
-                    units: addedUnits.map(u => u.serializeToClient())
-                });
+
+                this.ingame.broadcastAddUnits(region, addedUnits);
             });
 
             this.ingame.log({

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/execute-loan-game-state/the-faceless-men-game-state/TheFacelessMenGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-consolidate-power-game-state/execute-loan-game-state/the-faceless-men-game-state/TheFacelessMenGameState.ts
@@ -106,6 +106,13 @@ export default class TheFacelessMenGameState extends GameState<ExecuteLoanGameSt
         return [this.parentGameState.ingame.getControllerOfHouse(this.house).user];
     }
 
+    getRequiredVisibleRegionsForPlayer(player: Player): Region[] {
+        if (this.game.ingame.getControllerOfHouse(this.house) == player) {
+            return _.uniq(this.availableUnits.map(u => u.region));
+        }
+        return [];
+    }
+
     serializeToClient(_admin: boolean, _player: Player | null): SerializedTheFacelessMenGameState {
         return {
             type: "the-faceless-men",

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/PostCombatGameState.ts
@@ -145,11 +145,11 @@ export default class PostCombatGameState extends GameState<
             const oldGarrisonStrength = this.combat.defendingRegion.garrison;
             this.combat.defendingRegion.garrison = 0;
 
-            this.entireGame.broadcastToClients({
+            this.combat.ingameGameState.sendMessageToPlayersWhoCanSeeRegion({
                 type: "change-garrison",
                 region: this.combat.defendingRegion.id,
                 newGarrison: 0
-            });
+            }, this.combat.defendingRegion);
 
             this.parentGameState.ingameGameState.log({
                 type: "garrison-removed",

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/jon-connington-ability-game-state/JonConningtonAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/jon-connington-ability-game-state/JonConningtonAbilityGameState.ts
@@ -112,11 +112,8 @@ export default class JonConningtonAbilityGameState extends GameState<
                 });
                 const unit = this.game.createUnit(region, knight, house);
                 region.units.set(unit.id, unit);
-                this.entireGame.broadcastToClients({
-                    type: "add-units",
-                    regionId: region.id,
-                    units: [unit.serializeToClient()]
-                });
+
+                this.ingame.broadcastAddUnits(region, [unit]);
             }
 
             this.parentGameState.onHouseCardResolutionFinish(house);

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/mace-tyrell-asos-ability-game-state/MaceTyrellASoSAbilityGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/combat-game-state/post-combat-game-state/after-combat-house-card-abilities-game-state/mace-tyrell-asos-ability-game-state/MaceTyrellASoSAbilityGameState.ts
@@ -93,12 +93,12 @@ export default class MaceTyrellASoSAbilityGameState extends GameState<
             // Remove a possible order and log this for the case the defender decides to change the current order to Support or Defense
             this.combatGameState.actionGameState.removeOrderFromRegion(this.combatGameState.defendingRegion, true);
             this.combatGameState.actionGameState.ordersOnBoard.set(this.combatGameState.defendingRegion, chosenOrder);
-            this.combatGameState.entireGame.broadcastToClients({
+            this.ingame.sendMessageToPlayersWhoCanSeeRegion({
                 type: "action-phase-change-order",
                 region: this.combatGameState.defendingRegion.id,
                 order: chosenOrder.id,
                 animate: "white"
-            });
+            }, this.combatGameState.defendingRegion);
             this.ingame.log({
                 type: "mace-tyrell-asos-order-placed",
                 house: this.childGameState.house.id,

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/resolve-march-order-game-state/resolve-single-march-order-game-state/ResolveSingleMarchOrderGameState.ts
@@ -112,11 +112,11 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
                     });
                 }
 
-                this.entireGame.broadcastToClients({
+                this.ingame.sendMessageToPlayersWhoCanSeeRegion({
                     type: "change-control-power-token",
                     regionId: startingRegion.id,
                     houseId: this.house.id
-                });
+                }, startingRegion);
 
                 leftPowerToken = true;
             }
@@ -206,11 +206,11 @@ export default class ResolveSingleMarchOrderGameState extends GameState<ResolveM
                     region.garrison = 0;
                     this.resolveMarchOrderGameState.moveUnits(startingRegion, army, region);
 
-                    this.entireGame.broadcastToClients({
+                    this.ingame.sendMessageToPlayersWhoCanSeeRegion({
                         type: "change-garrison",
                         region: region.id,
                         newGarrison: region.garrison
-                    });
+                    }, region);
 
                     this.ingame.log({
                         type: "garrison-removed",

--- a/agot-bg-game-server/src/common/ingame-game-state/action-game-state/use-raven-game-state/replace-order-game-state/ReplaceOrderGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/action-game-state/use-raven-game-state/replace-order-game-state/ReplaceOrderGameState.ts
@@ -130,8 +130,11 @@ export default class ReplaceOrderGameState extends GameState<UseRavenGameState> 
             const order = orders.get(message.orderId);
 
             this.actionGameState.ordersOnBoard.set(region, order);
-            this.ingameGameState.ordersToBeAnimated.set(region, {highlight: {active: true, color: "white"}, animateAttention: true});
-            window.setTimeout(() => this.ingameGameState.ordersToBeAnimated.delete(region), 3000);
+
+            if (!this.ingameGameState.fogOfWar) {
+                this.ingameGameState.ordersToBeAnimated.set(region, {highlight: {active: true, color: "white"}, animateAttention: true});
+                window.setTimeout(() => this.ingameGameState.ordersToBeAnimated.delete(region), 3000);
+            }
         }
     }
 

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Game.ts
@@ -585,7 +585,7 @@ export default class Game {
         return {
             lastUnitId: this.lastUnitId,
             houses: this.houses.values.map(h => h.serializeToClient(admin, player, this)),
-            world: this.world.serializeToClient(),
+            world: this.world.serializeToClient(admin, player),
             turn: this.turn,
             ironThroneTrack: this.ironThroneTrack.map(h => h.id),
             fiefdomsTrack: this.fiefdomsTrack.map(h => h.id),

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLogManager.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLogManager.ts
@@ -12,6 +12,10 @@ export function ticksToTime(ticks: number): Date {
     return new Date(ticks * 1000);
 }
 
+const fogOfWarBannedLogs = [
+    'orders-revealed'
+]
+
 export default class GameLogManager {
     ingameGameState: IngameGameState;
     @observable logs: GameLog[] = [];
@@ -41,8 +45,17 @@ export default class GameLogManager {
     }
 
     serializeToClient(admin: boolean, user: User | null): SerializedGameLogManager {
+        const fogOfWar = this.ingameGameState.entireGame.gameSettings.fogOfWar
+
+        const filteredLogs = this.logs.filter((log) => {
+            if (!fogOfWar) return true
+            if (this.ingameGameState.isEnded) return true
+            if (this.ingameGameState.isCancelled) return true
+            return !fogOfWarBannedLogs.includes(log.data.type)
+        })
+
         return {
-            logs: this.logs.map(l => ({time: timeToTicks(l.time), data: l.data, resolvedAutomatically: l.resolvedAutomatically})),
+            logs: filteredLogs.map(l => ({time: timeToTicks(l.time), data: l.data, resolvedAutomatically: l.resolvedAutomatically})),
             lastSeenLogTimes: admin
                 ? this.lastSeenLogTimes.entries.map(([usr, time]) => [usr.id, time])
                 : user

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLogManager.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/GameLogManager.ts
@@ -14,7 +14,7 @@ export function ticksToTime(ticks: number): Date {
 
 const fogOfWarBannedLogs = [
     'orders-revealed'
-]
+];
 
 export default class GameLogManager {
     ingameGameState: IngameGameState;
@@ -45,14 +45,14 @@ export default class GameLogManager {
     }
 
     serializeToClient(admin: boolean, user: User | null): SerializedGameLogManager {
-        const fogOfWar = this.ingameGameState.entireGame.gameSettings.fogOfWar
+        const fogOfWar = this.ingameGameState.fogOfWar;
 
         const filteredLogs = this.logs.filter((log) => {
-            if (!fogOfWar) return true
-            if (this.ingameGameState.isEnded) return true
-            if (this.ingameGameState.isCancelled) return true
-            return !fogOfWarBannedLogs.includes(log.data.type)
-        })
+            if (!fogOfWar) return true;
+            if (this.ingameGameState.isEnded) return true;
+            if (this.ingameGameState.isCancelled) return true;
+            return !fogOfWarBannedLogs.includes(log.data.type);
+        });
 
         return {
             logs: filteredLogs.map(l => ({time: timeToTicks(l.time), data: l.data, resolvedAutomatically: l.resolvedAutomatically})),

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Region.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/Region.ts
@@ -11,6 +11,7 @@ import _ from "lodash";
 import getStaticWorld from "./static-data-structure/getStaticWorld";
 import { port } from "./regionTypes";
 import SnrError from "../../../utils/snrError";
+import Player from "../Player";
 
 export default class Region {
     game: Game;
@@ -188,16 +189,22 @@ export default class Region {
         return result;
     }
 
-    serializeToClient(): SerializedRegion {
+    serializeToClient(admin: boolean, player: Player | null): SerializedRegion {
+        const visible = admin || this.game.ingame.getVisibleRegionsForPlayer(player).includes(this);
+
         return {
             id: this.id,
-            units: this.units.values.map(u => u.serializeToClient()),
-            garrison: this.garrison,
-            controlPowerToken: this.controlPowerToken ? this.controlPowerToken.id : null,
-            loyaltyTokens: this.loyaltyTokens,
-            castleModifier: this.castleModifier,
-            barrelModifier: this.barrelModifier,
-            crownModifier: this.crownModifier,
+            units: visible ? this.units.values.map(u => u.serializeToClient()) : [],
+            garrison: visible ? this.garrison : 0,
+            controlPowerToken: visible
+                ? this.controlPowerToken
+                    ? this.controlPowerToken.id
+                    : null
+                : null,
+            loyaltyTokens: visible ? this.loyaltyTokens : 0,
+            castleModifier: visible ? this.castleModifier : 0,
+            barrelModifier: visible ? this.barrelModifier : 0,
+            crownModifier: visible ? this.crownModifier : 0,
             overwrittenSuperControlPowerToken: this.overwrittenSuperControlPowerToken ? this.overwrittenSuperControlPowerToken.id : null
         }
     }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/World.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/World.ts
@@ -14,6 +14,7 @@ import { dragon } from "./unitTypes";
 import staticWorld7p from "./static-data-structure/globalStaticWorld7p";
 import StaticIronBankView from "./static-data-structure/StaticIronBankView";
 import { GameSettings } from "../../../common/EntireGame";
+import Player from "../Player";
 
 export default class World {
     settings: GameSettings;
@@ -173,43 +174,8 @@ export default class World {
         return this.regions.values.filter(r => r.getController() == house);
     }
 
-    hasUnitsInRegion(
-        regionId: string,
-        house?: House,
-    ): boolean {
-        if (!house) return false
-
-        // Find regions controlled by house.
-        const controlledRegions = this.getControlledRegions(house);
-
-        const [controlledWithUnits] = _.partition(
-            controlledRegions,
-            (region) => (region.units.entries.length)
-        )
-
-        return controlledWithUnits
-            .map((region) => region.id)
-            .includes(regionId)
-    }
-    
-    getRegionIdsAdjacent(
-        house: House,
-    ): string[] {
-        // Find regions controlled by house.
-        const controlledRegions = this.getControlledRegions(house);
-
-        const [controlledWithUnits, controlledWithoutUnits] = _.partition(
-            controlledRegions,
-            (region) => (region.units.entries.length)
-        )
-
-        const neighboring = controlledWithUnits.map((region) => this.getNeighbouringRegions(region)).flat(1)
-
-        return [
-            ...controlledWithUnits.map(region => region.id),
-            ...controlledWithoutUnits.map(region => region.id),
-            ...neighboring.map(region => region.id),
-        ]
+    getAllRegionsWithControllers(): [Region, House | null][] {
+        return this.regions.values.map(r => [r, r.getController()]);
     }
 
     getValidRetreatRegions(startingRegion: Region, house: House, army: Unit[]): Region[] {
@@ -282,9 +248,9 @@ export default class World {
         return this.regions.values.map(r => r.getSnapshot());
     }
 
-    serializeToClient(): SerializedWorld {
+    serializeToClient(admin: boolean, player: Player | null): SerializedWorld {
         return {
-            regions: this.regions.values.map(r => r.serializeToClient()),
+            regions: this.regions.values.map(r => r.serializeToClient(admin, player)),
             settings: this.settings
         };
     }

--- a/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/SerLorasTyrellHouseCardAbility.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/game-data-structure/house-card/SerLorasTyrellHouseCardAbility.ts
@@ -16,12 +16,12 @@ export default class SerLorasTyrellHouseCardAbility extends HouseCardAbility {
                 afterCombat.combatGameState.order
             );
 
-            afterCombat.entireGame.broadcastToClients({
+            afterCombat.parentGameState.parentGameState.ingameGameState.sendMessageToPlayersWhoCanSeeRegion({
                 type: "action-phase-change-order",
                 region: afterCombat.combatGameState.defendingRegion.id,
                 order: afterCombat.combatGameState.order.id,
                 animate: "white"
-            });
+            }, afterCombat.combatGameState.defendingRegion);
 
             afterCombat.parentGameState.combat.ingameGameState.log({
                 type: "loras-tyrell-attack-order-moved",

--- a/agot-bg-game-server/src/common/ingame-game-state/pay-debts-game-state/resolve-single-pay-debt-game-state/ResolveSinglePayDebtGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/pay-debts-game-state/resolve-single-pay-debt-game-state/ResolveSinglePayDebtGameState.ts
@@ -95,6 +95,13 @@ export default class ResolveSinglePayDebtGameState extends GameState<PayDebtsGam
         return [this.parentGameState.ingame.getControllerOfHouse(this.resolver).user];
     }
 
+    getRequiredVisibleRegionsForPlayer(player: Player): Region[] {
+        if (this.ingame.getControllerOfHouse(this.resolver) == player) {
+            return _.uniq(this.availableUnitsOfHouse.map(u => u.region));
+        }
+        return [];
+    }
+
     serializeToClient(_admin: boolean, _player: Player | null): SerializedResolveSinglePayDebtGameState {
         return {
             type: "resolve-single-pay-debt",

--- a/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/planning-game-state/place-orders-game-state/PlaceOrdersGameState.ts
@@ -190,17 +190,31 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
                     region: region.id
                 });
 
-                this.entireGame.broadcastToClients({
-                    type: "order-placed",
-                    region: region.id,
-                    order: null
-                }, player.user);
+                if (!this.entireGame.gameSettings.fogOfWar) {
+                    this.entireGame.broadcastToClients({
+                        type: "order-placed",
+                        region: region.id,
+                        order: null
+                    }, player.user);
+                } else {
+                    const otherPlayers = _.difference(this.ingame.players.values, [player]);
+                    otherPlayers.forEach(op => {
+                        const visibleRegions = this.ingame.getVisibleRegionsForPlayer(op);
+                        if (visibleRegions.includes(region)) {
+                            this.entireGame.sendMessageToClients([op.user], {
+                                type: "order-placed",
+                                region: region.id,
+                                order: null
+                            });
+                        }
+                    });
+                }
             } else if (this.placedOrders.has(region)) {
                 this.placedOrders.delete(region);
-                this.entireGame.broadcastToClients({
+                this.ingame.sendMessageToPlayersWhoCanSeeRegion({
                     type: "remove-placed-order",
                     regionId: region.id
-                });
+                }, region);
             }
         } else if (message.type == "ready") {
             this.setReady(player);
@@ -240,7 +254,7 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
     }
 
     serializeToClient(admin: boolean, player: Player | null): SerializedPlaceOrdersGameState {
-        const placedOrders = this.placedOrders.mapOver(r => r.id, (o, r) => {
+        let placedOrders = this.placedOrders.mapOver(r => r.id, (o, r) => {
             // Hide orders that doesn't belong to the player
             // If admin, send all orders.
             const controller = r.getController();
@@ -249,6 +263,11 @@ export default class PlaceOrdersGameState extends GameState<PlanningGameState> {
             }
             return null;
         });
+
+        if (this.entireGame.gameSettings.fogOfWar && player != null) {
+            const visibleRegionIds = this.ingame.getVisibleRegionsForPlayer(player).map(r => r.id);
+            placedOrders = placedOrders.filter(([rid, _oid]) => visibleRegionIds.includes(rid));
+        }
 
         return {
             type: "place-orders",

--- a/agot-bg-game-server/src/common/ingame-game-state/select-orders-game-state/SelectOrdersGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/select-orders-game-state/SelectOrdersGameState.ts
@@ -73,6 +73,13 @@ export default class SelectOrdersGameState<P extends ParentGameState> extends Ga
         return [this.parentGameState.ingame.getControllerOfHouse(this.house).user];
     }
 
+    getRequiredVisibleRegionsForPlayer(player: Player): Region[] {
+        if (this.game.ingame.getControllerOfHouse(this.house) == player) {
+            return this.possibleRegions;
+        }
+        return [];
+    }
+
     selectOrders(regions: Region[]): void {
         this.entireGame.sendMessageToServer({
             type: "select-orders",

--- a/agot-bg-game-server/src/common/ingame-game-state/select-region-game-state/SelectRegionGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/select-region-game-state/SelectRegionGameState.ts
@@ -70,6 +70,13 @@ export default class SelectRegionGameState<P extends ParentGameState> extends Ga
         return [this.parentGameState.ingame.getControllerOfHouse(this.house).user];
     }
 
+    getRequiredVisibleRegionsForPlayer(player: Player): Region[] {
+        if (this.game.ingame.getControllerOfHouse(this.house) == player) {
+            return this.regions;
+        }
+        return [];
+    }
+
     serializeToClient(_admin: boolean, _player: Player | null): SerializedSelectRegionGameState {
         return {
             type: "select-region",

--- a/agot-bg-game-server/src/common/ingame-game-state/select-units-game-state/SelectUnitsGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/select-units-game-state/SelectUnitsGameState.ts
@@ -124,6 +124,13 @@ export default class SelectUnitsGameState<P extends SelectUnitsParentGameState> 
         return [this.parentGameState.ingame.getControllerOfHouse(this.house).user];
     }
 
+    getRequiredVisibleRegionsForPlayer(player: Player): Region[] {
+        if (this.game.ingame.getControllerOfHouse(this.house) == player) {
+            return _.uniq(this.possibleUnits.map(u => u.region));
+        }
+        return [];
+    }
+
     onServerMessage(_message: ServerMessage): void { }
 
     canPickUnit(u: Unit): boolean {

--- a/agot-bg-game-server/src/common/ingame-game-state/take-control-of-enemy-port-game-state/TakeControlOfEnemyPortGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/take-control-of-enemy-port-game-state/TakeControlOfEnemyPortGameState.ts
@@ -89,12 +89,7 @@ export default class TakeControlOfEnemyPortGameState extends GameState<ParentGam
 
             shipsToAdd.forEach(ship => this.port.units.set(ship.id, ship));
 
-            this.entireGame.broadcastToClients({
-                type: "add-units",
-                regionId: this.port.id,
-                units: shipsToAdd.map(ship => ship.serializeToClient()),
-                isTransform: true
-            });
+            this.ingame.broadcastAddUnits(this.port, shipsToAdd, true);
         }
 
         this.ingame.log({

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/mustering-game-state/player-mustering-game-state/PlayerMusteringGameState.ts
@@ -199,11 +199,7 @@ export default class PlayerMusteringGameState extends GameState<ParentGameState>
                 });
 
                 if (createdUnits.length > 0) {
-                    this.entireGame.broadcastToClients({
-                        type: "add-units",
-                        regionId: region.id,
-                        units: createdUnits.map(u => u.serializeToClient())
-                    });
+                    this.ingame.broadcastAddUnits(region, createdUnits);
                 }
             });
 

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/fire-made-flesh-game-state/FireMadeFleshGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/fire-made-flesh-game-state/FireMadeFleshGameState.ts
@@ -105,11 +105,8 @@ export default class FireMadeFleshGameState extends GameState<WesterosDeck4GameS
                 if (capital) {
                     const newDragon = this.game.createUnit(capital, dragon, house);
                     capital.units.set(newDragon.id, newDragon);
-                    this.entireGame.broadcastToClients({
-                        type: "add-units",
-                        regionId: capital.id,
-                        units: [newDragon.serializeToClient()]
-                    });
+
+                    this.ingame.broadcastAddUnits(capital, [newDragon]);
 
                     this.ingame.log({
                         type: "fire-made-flesh-choice",

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/move-loyalty-tokens-game-state/resolve-move-loyalty-token-game-state/ResolveMoveLoyaltyTokenGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/move-loyalty-tokens-game-state/resolve-move-loyalty-token-game-state/ResolveMoveLoyaltyTokenGameState.ts
@@ -8,6 +8,8 @@ import House from "../../../../game-data-structure/House";
 import Region from "../../../../game-data-structure/Region";
 import User from "../../../../../../server/User";
 import MoveLoyaltyTokensGameState from "../MoveLoyaltyTokensGameState";
+import { land } from "../../../../game-data-structure/regionTypes";
+import _ from "lodash";
 
 export default class ResolveMoveLoyaltyTokenGameState extends GameState<MoveLoyaltyTokensGameState> {
     house: House;
@@ -76,6 +78,14 @@ export default class ResolveMoveLoyaltyTokenGameState extends GameState<MoveLoya
 
     getWaitedUsers(): User[] {
         return [this.ingame.getControllerOfHouse(this.house).user];
+    }
+
+    getRequiredVisibleRegionsForPlayer(_player: Player): Region[] {
+        const regionsWithLT = this.ingame.world.regions.values.filter(r => r.loyaltyTokens > 0);
+
+        const adjacentRegions = _.flatMap(regionsWithLT.map(r => this.ingame.world.getNeighbouringRegions(r).filter(r2 => r2.type == land)));
+
+        return _.uniq(_.concat(regionsWithLT, adjacentRegions));
     }
 
     serializeToClient(_admin: boolean, _player: Player | null): SerializedResolveMoveLoyaltyTokenGameState {

--- a/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/playing-with-fire-game-state/PlayingWithFireGameState.ts
+++ b/agot-bg-game-server/src/common/ingame-game-state/westeros-game-state/westeros-deck-4-game-state/playing-with-fire-game-state/PlayingWithFireGameState.ts
@@ -117,12 +117,9 @@ export default class PlayingWithFireGameState extends GameState<WesterosDeck4Gam
             }
             const chosenUnitType = unitTypes.get(this.getChoices(house).values[choice]);
             const newUnit = this.game.createUnit(this.region, chosenUnitType, house);
+
             this.region.units.set(newUnit.id, newUnit);
-            this.entireGame.broadcastToClients({
-                type: "add-units",
-                regionId: this.region.id,
-                units: [newUnit.serializeToClient()]
-            });
+            this.ingame.broadcastAddUnits(this.region, [newUnit]);
 
             this.ingame.log({
                 type: "playing-with-fire-choice",

--- a/agot-bg-game-server/src/messages/ServerMessage.ts
+++ b/agot-bg-game-server/src/messages/ServerMessage.ts
@@ -13,6 +13,7 @@ import { CombatStats } from "../common/ingame-game-state/action-game-state/resol
 import { DraftStep } from "../common/ingame-game-state/draft-house-cards-game-state/DraftHouseCardsGameState";
 import { SerializedLoanCard } from "../common/ingame-game-state/game-data-structure/loan-card/LoanCard";
 import { SerializedWaitedForData } from "../common/ingame-game-state/Player";
+import { SerializedRegion } from "../common/ingame-game-state/game-data-structure/Region";
 
 export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | OrderPlaced | PlayerReady | PlayerUnready
     | HouseCardChosen | SupportDeclared | SupportRefused | NewTurn | RemovePlacedOrder
@@ -34,7 +35,7 @@ export type ServerMessage = NewUser | HouseChosen | AuthenticationResponse | Ord
     | StartPlayerClock | StopPlayerClock | GamePaused | GameResumed | LaterHouseCardsApplied
     | WildlingTiesResolved | PreemptiveRaidNewAttack | GameStarted | ReadyCheck | HousesSwapped
     | RevealOrders | RemoveOrders | AcceptAllLoyaltyTokenMovementsChanged | UpdateWaitedForData
-    | UserBanned | UserUnbanned;
+    | UserBanned | UserUnbanned | UpdateVisibleRegions;
 
 interface AuthenticationResponse {
     type: "authenticate-response";
@@ -557,4 +558,12 @@ interface UserBanned {
 interface UserUnbanned {
     type: "user-unbanned";
     userId: string;
+}
+
+interface UpdateVisibleRegions {
+    type: "update-visible-regions";
+    playerUserId: string;
+    regionsToMakeVisible: SerializedRegion[];
+    regionsToHide: string[];
+    ordersToMakeVisible: [string, number][];
 }

--- a/agot-bg-game-server/src/server/serializedGameMigrations.ts
+++ b/agot-bg-game-server/src/server/serializedGameMigrations.ts
@@ -2155,6 +2155,18 @@ const serializedGameMigrations: {version: string; migrate: (serializeGamed: any)
 
             return serializedGame;
         }
+    },
+    {
+        version: "110",
+        migrate: (serializedGame: any) => {
+            if (serializedGame.childGameState.type == "ingame") {
+                const ingame = serializedGame.childGameState;
+
+                ingame.visibleRegionsPerPlayer = [];
+            }
+
+            return serializedGame;
+        }
     }
 ];
 


### PR DESCRIPTION
This is my draft so far. I decided to obfuscate the game logs client side. I don't like this much, but as it is too much work now to do it server side I accept it for now for the logs. At least it's much harder to cheat with a textual representation of the board instead of a full visual one.

I am not totally satisfied yet as we have to synch the visible parts of the map with each player now. For ease I do it on every game-state-change but I still search for a less wasteful way of doing this...

The biggest issue though are states like QoT, which currently will break the game when players shall act in fogged areas... I am not totally sure how to solve it right now, but I think I will introduce a callback like map controls, which allows to set "required regions" from every game state. Feel free to continue with this...